### PR TITLE
Product CRUD API 정의

### DIFF
--- a/src/main/java/com/ecommerce/platform/domain/product/controller/ProductController.java
+++ b/src/main/java/com/ecommerce/platform/domain/product/controller/ProductController.java
@@ -1,0 +1,59 @@
+package com.ecommerce.platform.domain.product.controller;
+
+import com.ecommerce.platform.domain.product.dto.ProductRequest;
+import com.ecommerce.platform.domain.product.dto.ProductResponse;
+import com.ecommerce.platform.domain.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/products")
+@RequiredArgsConstructor
+public class ProductController {
+
+  private final ProductService productService;
+
+  // 상품 등록
+  @PostMapping
+  public ResponseEntity<ProductResponse> createProduct(@RequestBody ProductRequest request) {
+    ProductResponse response = productService.createProduct(request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  // 상품 목록 조회 (페이징, 정렬)
+  @GetMapping
+  public ResponseEntity<Page<ProductResponse>> getAllProducts(
+      @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+    Page<ProductResponse> responses = productService.getAllProducts(pageable);
+    return ResponseEntity.ok(responses);
+  }
+
+  // 상품 상세 조회
+  @GetMapping("/{id}")
+  public ResponseEntity<ProductResponse> getProductById(@PathVariable Long id) {
+    ProductResponse response = productService.getProductById(id);
+    return ResponseEntity.ok(response);
+  }
+
+  // 상품 수정
+  @PutMapping("/{id}")
+  public ResponseEntity<ProductResponse> updateProduct(
+      @PathVariable Long id,
+      @RequestBody ProductRequest request) {
+    ProductResponse response = productService.updateProduct(id, request);
+    return ResponseEntity.ok(response);
+  }
+
+  // 상품 삭제
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteProduct(@PathVariable Long id) {
+    productService.deleteProduct(id);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/ecommerce/platform/domain/product/dto/ProductRequest.java
+++ b/src/main/java/com/ecommerce/platform/domain/product/dto/ProductRequest.java
@@ -1,0 +1,16 @@
+package com.ecommerce.platform.domain.product.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ProductRequest {
+
+  private String name;
+  private String description;
+  private Integer price;
+  private Integer stockQuantity;
+}

--- a/src/main/java/com/ecommerce/platform/domain/product/dto/ProductResponse.java
+++ b/src/main/java/com/ecommerce/platform/domain/product/dto/ProductResponse.java
@@ -1,0 +1,29 @@
+package com.ecommerce.platform.domain.product.dto;
+
+import com.ecommerce.platform.domain.product.entity.Product;
+import com.ecommerce.platform.domain.product.entity.ProductStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProductResponse {
+
+  private Long id;
+  private String name;
+  private String description;
+  private Integer price;
+  private Integer stockQuantity;
+  private ProductStatus status;
+
+  public static ProductResponse from(Product product) {
+    return new ProductResponse(
+        product.getId(),
+        product.getName(),
+        product.getDescription(),
+        product.getPrice(),
+        product.getStockQuantity(),
+        product.getStatus()
+    );
+  }
+}

--- a/src/main/java/com/ecommerce/platform/domain/product/service/ProductService.java
+++ b/src/main/java/com/ecommerce/platform/domain/product/service/ProductService.java
@@ -1,12 +1,16 @@
 package com.ecommerce.platform.domain.product.service;
 
+import com.ecommerce.platform.domain.product.dto.ProductRequest;
+import com.ecommerce.platform.domain.product.dto.ProductResponse;
 import com.ecommerce.platform.domain.product.entity.Product;
 import com.ecommerce.platform.domain.product.repository.ProductRepository;
+import com.ecommerce.platform.global.common.exception.CustomException;
+import com.ecommerce.platform.global.common.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -17,20 +21,55 @@ public class ProductService {
 
   // 상품 등록
   @Transactional
-  public Product saveProduct(Product product) {
-    return productRepository.save(product);
+  public ProductResponse createProduct(ProductRequest request) {
+    Product product = new Product();
+    product.setName(request.getName());
+    product.setDescription(request.getDescription());
+    product.setPrice(request.getPrice());
+    product.setStockQuantity(request.getStockQuantity());
+
+    Product savedProduct = productRepository.save(product);
+    return ProductResponse.from(savedProduct);
   }
 
+  // 상품 목록 조회 (페이징)
+  public Page<ProductResponse> getAllProducts(Pageable pageable) {
+    return productRepository.findAll(pageable)
+        .map(ProductResponse::from);
+  }
 
+  // 상품 상세 조회
+  public ProductResponse getProductById(Long id) {
+    Product product = productRepository.findById(id)
+        .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+    return ProductResponse.from(product);
+  }
+
+  // 상품 수정
+  @Transactional
+  public ProductResponse updateProduct(Long id, ProductRequest request) {
+    Product product = productRepository.findById(id)
+        .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+    product.setName(request.getName());
+    product.setDescription(request.getDescription());
+    product.setPrice(request.getPrice());
+    product.setStockQuantity(request.getStockQuantity());
+
+    return ProductResponse.from(product);
+  }
+
+  // 상품 삭제
+  @Transactional
+  public void deleteProduct(Long id) {
+    Product product = productRepository.findById(id)
+        .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+    productRepository.delete(product);
+  }
+
+  // OrderService에서 사용하는 메서드 (호환성 유지)
   public Product findOne(Long itemId) {
     return productRepository.findById(itemId)
-        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다."));
+        .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
   }
-
-  // 전체 상품 조회
-  public List<Product> findAllProducts() {
-    return productRepository.findAll();
-  }
-
-
 }

--- a/src/test/java/com/ecommerce/platform/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/ecommerce/platform/domain/product/service/ProductServiceTest.java
@@ -1,0 +1,142 @@
+package com.ecommerce.platform.domain.product.service;
+
+import com.ecommerce.platform.domain.product.dto.ProductRequest;
+import com.ecommerce.platform.domain.product.dto.ProductResponse;
+import com.ecommerce.platform.domain.product.entity.Product;
+import com.ecommerce.platform.domain.product.entity.ProductStatus;
+import com.ecommerce.platform.domain.product.repository.ProductRepository;
+import com.ecommerce.platform.global.common.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+class ProductServiceTest {
+
+  @Autowired
+  ProductService productService;
+  @Autowired
+  ProductRepository productRepository;
+
+  @Test
+  void 상품등록() {
+    // given
+    ProductRequest request = new ProductRequest();
+    request.setName("테스트 상품");
+    request.setDescription("테스트 상품 설명");
+    request.setPrice(10000);
+    request.setStockQuantity(100);
+
+    // when
+    ProductResponse response = productService.createProduct(request);
+
+    // then
+    assertThat(response.getName()).isEqualTo("테스트 상품");
+    assertThat(response.getPrice()).isEqualTo(10000);
+    assertThat(response.getStockQuantity()).isEqualTo(100);
+    assertThat(response.getStatus()).isEqualTo(ProductStatus.AVAILABLE);
+  }
+
+  @Test
+  void 상품목록조회() {
+    // given
+    for (int i = 1; i <= 15; i++) {
+      Product product = new Product();
+      product.setName("상품" + i);
+      product.setPrice(1000 * i);
+      product.setStockQuantity(10);
+      productRepository.save(product);
+    }
+
+    Pageable pageable = PageRequest.of(0, 10);
+
+    // when
+    Page<ProductResponse> responses = productService.getAllProducts(pageable);
+
+    // then
+    assertThat(responses.getContent()).hasSize(10);
+    assertThat(responses.getTotalElements()).isGreaterThanOrEqualTo(15);
+  }
+
+  @Test
+  void id로상품조회() {
+    // given
+    Product product = new Product();
+    product.setName("조회 테스트 상품");
+    product.setPrice(5000);
+    product.setStockQuantity(50);
+    Product savedProduct = productRepository.save(product);
+
+    // when
+    ProductResponse response = productService.getProductById(savedProduct.getId());
+
+    // then
+    assertThat(response.getId()).isEqualTo(savedProduct.getId());
+    assertThat(response.getName()).isEqualTo("조회 테스트 상품");
+  }
+
+  @Test
+  void 존재하지않는상품조회시예외발생() {
+    // when & then
+    assertThatThrownBy(() -> productService.getProductById(999L))
+        .isInstanceOf(CustomException.class);
+  }
+
+  @Test
+  void 상품수정() {
+    // given
+    Product product = new Product();
+    product.setName("수정 전 상품");
+    product.setPrice(5000);
+    product.setStockQuantity(50);
+    Product savedProduct = productRepository.save(product);
+
+    ProductRequest request = new ProductRequest();
+    request.setName("수정 후 상품");
+    request.setDescription("수정된 설명");
+    request.setPrice(7000);
+    request.setStockQuantity(70);
+
+    // when
+    ProductResponse response = productService.updateProduct(savedProduct.getId(), request);
+
+    // then
+    assertThat(response.getName()).isEqualTo("수정 후 상품");
+    assertThat(response.getDescription()).isEqualTo("수정된 설명");
+    assertThat(response.getPrice()).isEqualTo(7000);
+    assertThat(response.getStockQuantity()).isEqualTo(70);
+  }
+
+  @Test
+  void 상품삭제() {
+    // given
+    Product product = new Product();
+    product.setName("삭제할 상품");
+    product.setPrice(3000);
+    product.setStockQuantity(30);
+    Product savedProduct = productRepository.save(product);
+    Long productId = savedProduct.getId();
+
+    // when
+    productService.deleteProduct(productId);
+
+    // then
+    assertThat(productRepository.findById(productId)).isEmpty();
+  }
+
+  @Test
+  void 존재하지않는상품시예외발생() {
+    // when & then
+    assertThatThrownBy(() -> productService.deleteProduct(999L))
+        .isInstanceOf(CustomException.class);
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
https://github.com/celinayk/ecommerce-platform/issues/13

## 📝작업 내용
- ProductRequest, ProductResponse DTO 생성
  - ProductService CRUD 메서드 구현 (DTO 기반)
  - ProductController REST API 엔드포인트 구현
  - JPA Pageable을 활용한 페이징 처리
  - CustomException 적용한 에러 처리
  - ProductServiceTest 테스트 코드 작성 (7개 테스트 케이스)

  📋구현된 API
  - `POST /api/products` - 상품 등록
  - `GET /api/products` - 상품 목록 조회 (페이징, 정렬)
  - `GET /api/products/{id}` - 상품 상세 조회
  - `PUT /api/products/{id}` - 상품 수정
  - `DELETE /api/products/{id}` - 상품 삭제

  📋변경된 파일
  - `ProductRequest.java` - 상품 등록/수정 요청 DTO
  - `ProductResponse.java` - 상품 응답 DTO
  - `ProductService.java` - CRUD 비즈니스 로직
  - `ProductController.java` - REST API 엔드포인트
  - `ProductServiceTest.java` - 테스트 코드

  ✅테스트
  - Postman으로 전체 API 동작 확인 완료
  - 단위 테스트 7개 작성 및 통과
  
## 스크린샷 (선택)
