### PR TITLE
Order CRUD API 정의

### DIFF
--- a/src/main/java/com/ecommerce/platform/domain/order/controller/OrderController.java
+++ b/src/main/java/com/ecommerce/platform/domain/order/controller/OrderController.java
@@ -1,0 +1,50 @@
+package com.ecommerce.platform.domain.order.controller;
+
+import com.ecommerce.platform.domain.order.dto.OrderRequest;
+import com.ecommerce.platform.domain.order.dto.OrderResponse;
+import com.ecommerce.platform.domain.order.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+  private final OrderService orderService;
+
+  // 주문 생성
+  @PostMapping
+  public ResponseEntity<OrderResponse> createOrder(@RequestBody OrderRequest request) {
+    OrderResponse response = orderService.createOrder(request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  // 주문 목록 조회 (페이징, 정렬)
+  @GetMapping
+  public ResponseEntity<Page<OrderResponse>> getAllOrders(
+      @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+    Page<OrderResponse> responses = orderService.getAllOrders(pageable);
+    return ResponseEntity.ok(responses);
+  }
+
+  // 주문 상세 조회
+  @GetMapping("/{id}")
+  public ResponseEntity<OrderResponse> getOrderById(@PathVariable Long id) {
+    OrderResponse response = orderService.getOrderById(id);
+    return ResponseEntity.ok(response);
+  }
+
+  // 주문 취소
+  @PostMapping("/{id}/cancel")
+  public ResponseEntity<Void> cancelOrder(@PathVariable Long id) {
+    orderService.cancelOrder(id);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/ecommerce/platform/domain/order/dto/OrderRequest.java
+++ b/src/main/java/com/ecommerce/platform/domain/order/dto/OrderRequest.java
@@ -1,0 +1,15 @@
+package com.ecommerce.platform.domain.order.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class OrderRequest {
+
+  private Long userId;
+  private Long productId;
+  private Integer count;
+}

--- a/src/main/java/com/ecommerce/platform/domain/order/dto/OrderResponse.java
+++ b/src/main/java/com/ecommerce/platform/domain/order/dto/OrderResponse.java
@@ -1,0 +1,58 @@
+package com.ecommerce.platform.domain.order.dto;
+
+import com.ecommerce.platform.domain.order.entity.Order;
+import com.ecommerce.platform.domain.order.entity.OrderItem;
+import com.ecommerce.platform.domain.order.entity.OrderStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public class OrderResponse {
+
+  private Long id;
+  private Long userId;
+  private String userName;
+  private Integer totalAmount;
+  private OrderStatus status;
+  private List<OrderItemInfo> orderItems;
+  private LocalDateTime createdAt;
+
+  @Getter
+  @AllArgsConstructor
+  public static class OrderItemInfo {
+    private Long productId;
+    private String productName;
+    private Integer price;
+    private Integer quantity;
+    private Integer subtotal;
+
+    public static OrderItemInfo from(OrderItem orderItem) {
+      return new OrderItemInfo(
+          orderItem.getProduct().getId(),
+          orderItem.getProduct().getName(),
+          orderItem.getPrice(),
+          orderItem.getQuantity(),
+          orderItem.getSubtotal()
+      );
+    }
+  }
+
+  public static OrderResponse from(Order order) {
+    return new OrderResponse(
+        order.getId(),
+        order.getUser().getId(),
+        order.getUser().getName(),
+        order.getTotalAmount(),
+        order.getStatus(),
+        order.getOrderItems().stream()
+            .map(OrderItemInfo::from)
+            .collect(Collectors.toList()),
+        order.getCreatedAt()
+    );
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
https://github.com/celinayk/ecommerce-platform/issues/15

## 📝작업 내용
- OrderRequest, OrderResponse DTO 생성
    - 주문 생성 요청 DTO (userId, productId, count)
    - 주문 응답 DTO (주문 정보, 주문 아이템 리스트, 총 금액)
  - OrderService 비즈니스 로직 구현
    - 주문 생성 (재고 감소 처리)
    - 주문 목록 조회 (페이징)
    - 주문 상세 조회
    - 주문 취소 (재고 복구 처리)
  - OrderController REST API 엔드포인트 구현
    - JPA Pageable을 활용한 페이징 처리
    - CustomException 적용한 에러 처리
  - OrderServiceTest 테스트 코드 작성 (7개 테스트 케이스)
    - 주문 생성 및 재고 감소 검증
    - 주문 목록/상세 조회
    - 주문 취소 및 재고 복구
    - 예외 처리 케이스
    
## 📋구현된 API

  - POST /api/orders - 주문 생성
  - GET /api/orders - 주문 목록 조회 (페이징, 정렬)
  - GET /api/orders/{id} - 주문 상세 조회
  - POST /api/orders/{id}/cancel - 주문 취소

  ## 📋변경된 파일

  - OrderRequest.java - 주문 생성 요청 DTO
  - OrderResponse.java - 주문 응답 DTO
  - OrderService.java - 주문 비즈니스 로직
  - OrderController.java - REST API 엔드포인트
  - OrderServiceTest.java - 테스트 코드 (7개)

  ## ✅테스트

  - Postman으로 전체 API 동작 확인 완료
  - 단위 테스트 7개 작성 및 통과
    - 주문 생성, 목록 조회, 상세 조회
    - 주문 취소, 중복 취소 예외
    - 재고 수량 초과 예외
    - 존재하지 않는 주문 조회 예외