### PR TITLE
User Validation 검증 로직 추가

### DIFF
--- a/src/main/java/com/ecommerce/platform/domain/user/controller/UserController.java
+++ b/src/main/java/com/ecommerce/platform/domain/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.ecommerce.platform.domain.user.dto.UserLoginRequest;
 import com.ecommerce.platform.domain.user.dto.UserResponse;
 import com.ecommerce.platform.domain.user.dto.UserSignupRequest;
 import com.ecommerce.platform.domain.user.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,14 +21,14 @@ public class UserController {
 
   // 회원가입
   @PostMapping("/signup")
-  public ResponseEntity<UserResponse> signup(@RequestBody UserSignupRequest request) {
+  public ResponseEntity<UserResponse> signup(@Valid @RequestBody UserSignupRequest request) {
     UserResponse response = userService.signup(request);
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
   // 로그인
   @PostMapping("/login")
-  public ResponseEntity<UserResponse> login(@RequestBody UserLoginRequest request) {
+  public ResponseEntity<UserResponse> login(@Valid @RequestBody UserLoginRequest request) {
     UserResponse response = userService.login(request);
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/ecommerce/platform/domain/user/dto/UserLoginRequest.java
+++ b/src/main/java/com/ecommerce/platform/domain/user/dto/UserLoginRequest.java
@@ -1,5 +1,7 @@
 package com.ecommerce.platform.domain.user.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,6 +11,10 @@ import lombok.Setter;
 @NoArgsConstructor
 public class UserLoginRequest {
 
+  @NotBlank(message = "이메일은 필수입니다.")
+  @Email(message = "이메일 형식이 올바르지 않습니다.")
   private String email;
+
+  @NotBlank(message = "비밀번호는 필수입니다.")
   private String password;
 }

--- a/src/main/java/com/ecommerce/platform/domain/user/dto/UserSignupRequest.java
+++ b/src/main/java/com/ecommerce/platform/domain/user/dto/UserSignupRequest.java
@@ -1,5 +1,8 @@
 package com.ecommerce.platform.domain.user.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,7 +12,14 @@ import lombok.Setter;
 @NoArgsConstructor
 public class UserSignupRequest {
 
+  @NotBlank(message = "이메일은 필수입니다.")
+  @Email(message = "이메일 형식이 올바르지 않습니다.")
   private String email;
+
+  @NotBlank(message = "비밀번호는 필수입니다.")
+  @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
   private String password;
+
+  @NotBlank(message = "이름은 필수입니다.")
   private String name;
 }

--- a/src/test/java/com/ecommerce/platform/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/ecommerce/platform/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,188 @@
+package com.ecommerce.platform.domain.user.controller;
+
+import com.ecommerce.platform.domain.user.dto.UserSignupRequest;
+import com.ecommerce.platform.domain.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class UserControllerTest {
+
+  @Autowired
+  MockMvc mockMvc;
+  @Autowired
+  ObjectMapper objectMapper;
+  @Autowired
+  UserRepository userRepository;
+
+  @Test
+  void 회원가입_성공() throws Exception {
+    // given
+    UserSignupRequest request = new UserSignupRequest();
+    request.setEmail("test@example.com");
+    request.setPassword("password123");
+    request.setName("테스트유저");
+
+    // when & then
+    mockMvc.perform(post("/api/users/signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.email").value("test@example.com"))
+        .andExpect(jsonPath("$.name").value("테스트유저"));
+  }
+
+  @Test
+  void 회원가입_이메일필수검증() throws Exception {
+    // given
+    UserSignupRequest request = new UserSignupRequest();
+    request.setEmail(""); // 빈 이메일
+    request.setPassword("password123");
+    request.setName("테스트유저");
+
+    // when & then
+    mockMvc.perform(post("/api/users/signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+        .andExpect(jsonPath("$.errors.email").exists());
+  }
+
+  @Test
+  void 회원가입_이메일형식검증() throws Exception {
+    // given
+    UserSignupRequest request = new UserSignupRequest();
+    request.setEmail("invalid-email"); // 잘못된 이메일 형식
+    request.setPassword("password123");
+    request.setName("테스트유저");
+
+    // when & then
+    mockMvc.perform(post("/api/users/signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+        .andExpect(jsonPath("$.errors.email").exists());
+  }
+
+  @Test
+  void 회원가입_비밀번호필수검증() throws Exception {
+    // given
+    UserSignupRequest request = new UserSignupRequest();
+    request.setEmail("test@example.com");
+    request.setPassword(""); // 빈 비밀번호
+    request.setName("테스트유저");
+
+    // when & then
+    mockMvc.perform(post("/api/users/signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+        .andExpect(jsonPath("$.errors.password").exists());
+  }
+
+  @Test
+  void 회원가입_비밀번호길이검증() throws Exception {
+    // given
+    UserSignupRequest request = new UserSignupRequest();
+    request.setEmail("test@example.com");
+    request.setPassword("short"); // 8자 미만
+    request.setName("테스트유저");
+
+    // when & then
+    mockMvc.perform(post("/api/users/signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+        .andExpect(jsonPath("$.errors.password").exists());
+  }
+
+  @Test
+  void 회원가입_이름필수검증() throws Exception {
+    // given
+    UserSignupRequest request = new UserSignupRequest();
+    request.setEmail("test@example.com");
+    request.setPassword("password123");
+    request.setName(""); // 빈 이름
+
+    // when & then
+    mockMvc.perform(post("/api/users/signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+        .andExpect(jsonPath("$.errors.name").exists());
+  }
+
+  @Test
+  void 로그인_이메일필수검증() throws Exception {
+    // given
+    String requestBody = """
+        {
+          "email": "",
+          "password": "password123"
+        }
+        """;
+
+    // when & then
+    mockMvc.perform(post("/api/users/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+        .andExpect(jsonPath("$.errors.email").exists());
+  }
+
+  @Test
+  void 로그인_이메일형식검증() throws Exception {
+    // given
+    String requestBody = """
+        {
+          "email": "invalid-email",
+          "password": "password123"
+        }
+        """;
+
+    // when & then
+    mockMvc.perform(post("/api/users/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+        .andExpect(jsonPath("$.errors.email").exists());
+  }
+
+  @Test
+  void 로그인_비밀번호필수검증() throws Exception {
+    // given
+    String requestBody = """
+        {
+          "email": "test@example.com",
+          "password": ""
+        }
+        """;
+
+    // when & then
+    mockMvc.perform(post("/api/users/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+        .andExpect(jsonPath("$.errors.password").exists());
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
https://github.com/celinayk/ecommerce-platform/issues/17

## 📝작업 내용
  - 회원가입 및 로그인 요청 DTO에 검증 어노테이션 추가
  - Controller에 @Valid 적용하여 자동 검증 활성화
  - GlobalExceptionHandler에 검증 실패 예외 처리 추가
  - 검증 기능에 대한 통합 테스트 작성
  
## ✅테스트
 - ✅ 회원가입_성공
  - ✅ 회원가입_이메일필수검증
  - ✅ 회원가입_이메일형식검증
  - ✅ 회원가입_비밀번호필수검증
  - ✅ 회원가입_비밀번호길이검증
  - ✅ 회원가입_이름필수검증
  - ✅ 로그인_이메일필수검증
  - ✅ 로그인_이메일형식검증
  - ✅ 로그인_비밀번호필수검증